### PR TITLE
Added Vehicle Drift Suspension

### DIFF
--- a/SharedClasses/PermissionsManager.cs
+++ b/SharedClasses/PermissionsManager.cs
@@ -100,6 +100,7 @@ namespace vMenuShared
             VOFlashHighbeamsOnHonk,
             VODisableTurbulence,
             VOInfiniteFuel,
+            VOReduceDriftSuspension,
             VOFlares,
             VOPlaneBombs,
             #endregion

--- a/vMenu/CommonFunctions.cs
+++ b/vMenu/CommonFunctions.cs
@@ -1597,6 +1597,34 @@ namespace vMenuClient
         }
         #endregion
 
+        #region Set Reduce Drift Suspension
+        public static void SetVehicleDriftSuspension()
+        {
+            // Only continue if the player is in a vehicle.
+            if (Game.PlayerPed.IsInVehicle())
+            {
+                // Get the vehicle.
+                Vehicle veh = GetVehicle();
+
+                // If the vehicle as the requirement to do this.
+                var StrAdvancedFlags = GetVehicleHandlingInt( veh.Handle, "CCarHandlingData", "strAdvancedFlags" );
+                if (StrAdvancedFlags == 0) 
+                {
+                    Notify.Error("This vehicle doesn't have the requirement to do this.", true, false);
+                    return;
+                }
+
+                // We send to all client
+                BaseScript.TriggerServerEvent("vMenu:SetDriftSuspension", veh.NetworkId);
+            }
+            // The player is not inside a vehicle.
+            else
+            {
+                Notify.Error(CommonErrors.NoVehicle);
+            }
+        }
+        #endregion
+
         #region Get Saved Vehicles Dictionary
         /// <summary>
         /// Returns a collection of all saved vehicles, with their save name and saved vehicle info struct.

--- a/vMenu/EventManager.cs
+++ b/vMenu/EventManager.cs
@@ -46,6 +46,7 @@ namespace vMenuClient
             EventHandlers.Add("vMenu:updatePedDecors", new Action(UpdatePedDecors));
             EventHandlers.Add("playerSpawned", new Action(SetAppearanceOnFirstSpawn));
             EventHandlers.Add("vMenu:GetOutOfCar", new Action<int, int>(GetOutOfCar));
+            EventHandlers.Add("vMenu:SetDriftSuspension", new Action<int, bool>(SetDriftSuspension));
             EventHandlers.Add("vMenu:PrivateMessage", new Action<string, string>(PrivateMessage));
             EventHandlers.Add("vMenu:UpdateTeleportLocations", new Action<string>(UpdateTeleportLocations));
 
@@ -436,6 +437,22 @@ namespace vMenuClient
                     }
                 }
             }
+        }
+
+        private void SetDriftSuspension(int vehNetId, bool status)
+        {
+            int veh = NetToVeh(vehNetId);
+
+            // We apply thes flags
+            SetVehicleHandlingField( veh, "CCarHandlingData", "fBackEndPopUpCarImpulseMult", (int)0.100000 );
+            SetVehicleHandlingField( veh, "CCarHandlingData", "fBackEndPopUpBuildingImpulseMult", (int)0.030000 );
+            SetVehicleHandlingField( veh, "CCarHandlingData", "fBackEndPopUpMaxDeltaSpeed", (int)0.600000 );
+
+            SetVehicleHandlingField( veh, "CCarHandlingData", "strAdvancedFlags", 0x8000 + 0x4000000 );
+
+            // We enable or disable the suspension
+            SetReduceDriftVehicleSuspension( veh, status );
+
         }
 
         /// <summary>

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -88,12 +88,13 @@ namespace vMenuClient
             MenuCheckboxItem highbeamsOnHonk = new MenuCheckboxItem("Flash Highbeams On Honk", "Turn on your highbeams on your vehicle when honking your horn. Does not work during the day when you have your lights turned off.", FlashHighbeamsOnHonk);
             MenuCheckboxItem showHealth = new MenuCheckboxItem("Show Vehicle Health", "Shows the vehicle health on the screen.", VehicleShowHealth);
             MenuCheckboxItem infiniteFuel = new MenuCheckboxItem("Infinite Fuel", "Enables or disables infinite fuel for this vehicle, only works if FRFuel is installed.", VehicleInfiniteFuel);
-
+            
             // Create buttons.
             MenuItem fixVehicle = new MenuItem("Repair Vehicle", "Repair any visual and physical damage present on your vehicle.");
             MenuItem cleanVehicle = new MenuItem("Wash Vehicle", "Clean your vehicle.");
             MenuItem toggleEngine = new MenuItem("Toggle Engine On/Off", "Turn your engine on/off.");
             MenuItem setLicensePlateText = new MenuItem("Set License Plate Text", "Enter a custom license plate for your vehicle.");
+            MenuItem reduceDriftSuspension = new MenuItem("Reduce Drift Suspension", "Reduce the suspension of the vehicle to make it even lower to drift.~r~~h~This modification disable the original strAdvancedFlag of the car !!~s~~h~");
             MenuItem modMenuBtn = new MenuItem("Mod Menu", "Tune and customize your vehicle here.")
             {
                 Label = "→→→"
@@ -387,6 +388,9 @@ namespace vMenuClient
             {
                 menu.AddMenuItem(infiniteFuel);
             }
+            if (IsAllowed(Permission.VOReduceDriftSuspension)) {
+                menu.AddMenuItem(reduceDriftSuspension);
+            }
             // always allowed
             menu.AddMenuItem(showHealth); // SHOW VEHICLE HEALTH
 
@@ -530,6 +534,10 @@ namespace vMenuClient
                                 // Set the vehicle invisible or invincivble.
                                 vehicle.IsVisible = !vehicle.IsVisible;
                             }
+                        }
+                        else if (item == reduceDriftSuspension)
+                        {
+                            SetVehicleDriftSuspension();
                         }
                     }
 

--- a/vMenu/menus/VehicleOptions.cs
+++ b/vMenu/menus/VehicleOptions.cs
@@ -94,7 +94,7 @@ namespace vMenuClient
             MenuItem cleanVehicle = new MenuItem("Wash Vehicle", "Clean your vehicle.");
             MenuItem toggleEngine = new MenuItem("Toggle Engine On/Off", "Turn your engine on/off.");
             MenuItem setLicensePlateText = new MenuItem("Set License Plate Text", "Enter a custom license plate for your vehicle.");
-            MenuItem reduceDriftSuspension = new MenuItem("Reduce Drift Suspension", "Reduce the suspension of the vehicle to make it even lower to drift.~r~~h~This modification disable the original strAdvancedFlag of the car !!~s~~h~");
+            MenuItem reduceDriftSuspension = new MenuItem("Reduce Drift Suspension", "Reduce the suspension of the vehicle to make it even lower to drift. Use the option again to revert back to your original suspension. ~r~~h~This modification disables the original strAdvancedFlag of the vehicle!~s~~h~");
             MenuItem modMenuBtn = new MenuItem("Mod Menu", "Tune and customize your vehicle here.")
             {
                 Label = "→→→"

--- a/vMenuServer/MainServer.cs
+++ b/vMenuServer/MainServer.cs
@@ -1019,5 +1019,22 @@ namespace vMenuServer
         }
 
         #endregion
+
+        #region Set drift suspension
+
+        [EventHandler("vMenu:SetDriftSuspension")]
+        private void SetDriftSuspension(int vehNetId)
+        {
+            Entity vehEntity = Entity.FromNetworkId(vehNetId);
+            if (vehEntity == null) return;
+
+            StateBag vehState = vehEntity.State;
+            bool? reduceDriftSuspension = vehState["Set:ReduceDriftSuspension"] ?? false;
+
+            vehEntity.State["Set:ReduceDriftSuspension"] = reduceDriftSuspension.Value ? false : true;
+            TriggerClientEvent( "vMenu:SetDriftSuspension", vehNetId, vehEntity.State["Set:ReduceDriftSuspension"] );
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Vehicles since 2018 have had a handling flag called "strAdvancedFlag." This particular flag enables various features, such as the small airlift added to GTA: Online when the vehicle has the correct "strAdvancedFlag" to raise or lower it. As long as a car's handling includes the "strAdvancedFlag" line, we will apply the code for flag 4008000 using a command.

The vehicle will temporarily have this code applied to its "strAdvancedFlag" until it's deleted. Afterward, we invoke a native function from GTA V that utilizes this code 4008000, thus allowing the vehicle to be raised or lowered, similar to how it works in GTA: Online. 

[Preview Video](https://streamable.com/6wbb3k)

L'kid Workshop Team 🦦